### PR TITLE
improve compat: replace require with sass import

### DIFF
--- a/src/js/components/vue-scrollbar.vue
+++ b/src/js/components/vue-scrollbar.vue
@@ -35,12 +35,15 @@
 
 </template>
 
+<style lang="sass">
+  @import "../../sass/_Scrollbar.sass";
+</style>
+
 <script>
 
   import verticalScrollbar from './vertical-scrollbar.vue';
   import horizontalScrollbar from './horizontal-scrollbar.vue';
 
-  require('../../sass/_Scrollbar.sass');
 
   export default {
 


### PR DESCRIPTION
Couldn't import your lib without this in my browserify setup.
Feel free to merge/decline.
